### PR TITLE
use asterix pins to prevent major package updates

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,18 +5,18 @@ package:
   version: {{ version }}
 
 build:
-  number: 1
+  number: 2
   noarch: generic
 
 requirements:
   run:
-    - dask-gateway >=0.6
-    - dask-labextension >=1.1
-    - jupyter-server-proxy >=1.2
-    - jupyterhub >=1.1
-    - jupyterlab >=1.2
-    - nbgitpuller >=0.8
-    - pangeo-dask >=0.0.2
+    - pangeo-dask =0.0.2
+    - dask-gateway =0.6*
+    - dask-labextension =1.1*
+    - jupyter-server-proxy =1.2*
+    - jupyterhub =1.1*
+    - jupyterlab =1.2*
+    - nbgitpuller =0.8*
 
 test:
   commands:


### PR DESCRIPTION
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)

fixes https://github.com/pangeo-data/pangeo-stacks-dev/pull/13#issuecomment-593639904