### PR TITLE
bump versions

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,21 +1,20 @@
-{% set version = "0.0.2" %}
+{% set version = "0.0.3" %}
 
 package:
   name: pangeo-notebook
   version: {{ version }}
 
 build:
-  number: 2
+  number: 0
   noarch: generic
 
 requirements:
   run:
-    - pangeo-dask =0.0.2
-    - dask-gateway =0.6*
-    - dask-labextension =1.1*
-    - jupyter-server-proxy =1.2*
+    - pangeo-dask =0.0.3
+    - dask-labextension =2.1*
+    - jupyter-server-proxy =1.3*
     - jupyterhub =1.1*
-    - jupyterlab =1.2*
+    - jupyterlab =2.0*
     - nbgitpuller =0.8*
 
 test:
@@ -32,3 +31,4 @@ extra:
   recipe-maintainers:
     - scottyhq 
     - jhamman
+    - TomAugspurger


### PR DESCRIPTION
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

cc @jhamman @TomAugspurger - Perhaps we should start using different versions numbers so 1.0.3 (corresponding to juptyterlab 1.0, and then follow up with a seperate PR for 2.0.0 that moves to jupyterlab 2.0) ? Thoughts? 