### PR TITLE
new dask build, wait on jlab2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2020.03.27" %}
+{% set version = "2020.03.30" %}
 
 package:
   name: pangeo-notebook
@@ -10,9 +10,9 @@ build:
 
 requirements:
   run:
-    - pangeo-dask =2020.03.27
+    - pangeo-dask =2020.03.30
     - dask-labextension =1.1*
-    - jupyter-server-proxy =1.2*
+    - jupyter-server-proxy =1.3*
     - jupyterhub =1.1*
     - jupyterlab =1.2*
     - nbgitpuller =0.8*


### PR DESCRIPTION
Going to hold off on bumping to jupyterlab 2, and for now just point to new dask metapackage

Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.
