### PR TITLE
jupyterhub to jupyterhub-singleuser package

### DIFF
--- a/.github/workflows/watch-conda-forge.yml
+++ b/.github/workflows/watch-conda-forge.yml
@@ -93,15 +93,15 @@ jobs:
         uses: jacobtomlinson/gha-anaconda-package-version@0.1.1
         with:
           org: "conda-forge"
-          package: "jupyterhub"
+          package: "jupyterhub-singleuser"
 
       - name: Find and Replace jupyterhub
         id: jupyterhub
         uses: jacobtomlinson/gha-find-replace@0.1.1
         with:
           include: "meta.yaml"
-          find: "jupyterhub =.*"
-          replace: "jupyterhub =${{ steps.latest_version_jupyterhub.outputs.version }}"
+          find: "jupyterhub-singleuser =.*"
+          replace: "jupyterhub-singleuser =${{ steps.latest_version_jupyterhub.outputs.version }}"
 
 #       - name: Get latest jupyterlab version
 #         id: latest_version_jupyterlab

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ requirements:
     - dask-labextension =2.0.2
     - ipywidgets =7.5.1
     - jupyter-server-proxy =1.5.0
-    - jupyterhub =1.1.0
+    - jupyterhub-singleuser =1.1.0
     - jupyterlab >=2
     - nbgitpuller =0.8.0
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2020.05.29" %}
+{% set version = "2020.06.03" %}
 
 package:
   name: pangeo-notebook


### PR DESCRIPTION
We don't need the full jupyterhub, just what is required for user notebook sessions https://github.com/conda-forge/jupyterhub-feedstock/issues/23

This also matches repo2docker https://github.com/jupyter/repo2docker/blob/356ea1086868d36fdfd5be2e0d21fc4dae33b060/repo2docker/buildpacks/conda/environment.yml

Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.