### PR TITLE
add nodejs

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 0
+  number: 1
   noarch: generic
 
 requirements:
@@ -17,6 +17,7 @@ requirements:
     - jupyterhub-singleuser =1.1.0
     - jupyterlab >=2
     - nbgitpuller =0.8.0
+    - nodejs >=12
 
 test:
   commands:


### PR DESCRIPTION
Follow-on to https://github.com/conda-forge/pangeo-notebook-feedstock/pull/26 , we don't get nodejs by default and need it for jupyterlab extensions, so making it required. 

Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.