### PR TITLE
quick fix for labextension

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -6,3 +6,6 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-comp7
+zip_keys:
+- - cdt_name
+  - docker_image

--- a/.github/workflows/watch-conda-forge.yml
+++ b/.github/workflows/watch-conda-forge.yml
@@ -50,13 +50,13 @@ jobs:
           org: "conda-forge"
           package: "dask-labextension"
 
-      - name: Find and Replace dask-labextension
-        id: labextension
-        uses: jacobtomlinson/gha-find-replace@0.1.1
-        with:
-          include: "meta.yaml"
-          find: "dask-labextension =.*"
-          replace: "dask-labextension =${{ steps.latest_version_labext.outputs.version }}"
+#      - name: Find and Replace dask-labextension
+#        id: labextension
+#        uses: jacobtomlinson/gha-find-replace@0.1.1
+#        with:
+#          include: "meta.yaml"
+#          find: "dask-labextension =.*"
+#          replace: "dask-labextension =${{ steps.latest_version_labext.outputs.version }}"
 
       # - name: Get latest ipywidgets version
       #   id: latest_version_ipywidgets

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2021.01.05" %}
+{% set version = "2021.01.11" %}
 
 package:
   name: pangeo-notebook
@@ -11,8 +11,8 @@ build:
 requirements:
   run:
     - pangeo-dask =2020.12.11
-    - dask-labextension =4.0.1
-    - ipywidgets =7.5.1
+    - dask-labextension =3
+    - ipywidgets =7
     - jupyter-server-proxy =1.5.2
     - jupyterhub-singleuser =1.3.0
     - jupyterlab =2


### PR DESCRIPTION
Pin dask-labextension=3  (as temporary solution to https://github.com/pangeo-data/pangeo-docker-images/issues/177) 

NOTE: this also requires postBuild scripts with the correct extension for Jlab=2
`jupyter labextension install --clean  dask-labextension@3.0.0`

Also relax pin on ipywidgets (which wasn't being updated by CI)
https://github.com/conda-forge/pangeo-notebook-feedstock/blob/db089d22d0f15c6a0cbeb9668b505a0209f30722/.github/workflows/watch-conda-forge.yml#L61-L66

* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.


