### PR TITLE
jlab=3. dask-labextension=5

### DIFF
--- a/.github/workflows/watch-conda-forge.yml
+++ b/.github/workflows/watch-conda-forge.yml
@@ -50,28 +50,28 @@ jobs:
           org: "conda-forge"
           package: "dask-labextension"
 
-#      - name: Find and Replace dask-labextension
-#        id: labextension
-#        uses: jacobtomlinson/gha-find-replace@0.1.1
-#        with:
-#          include: "meta.yaml"
-#          find: "dask-labextension =.*"
-#          replace: "dask-labextension =${{ steps.latest_version_labext.outputs.version }}"
+      - name: Find and Replace dask-labextension
+        id: labextension
+        uses: jacobtomlinson/gha-find-replace@0.1.1
+        with:
+          include: "meta.yaml"
+          find: "dask-labextension =.*"
+          replace: "dask-labextension =${{ steps.latest_version_labext.outputs.version }}"
 
-      # - name: Get latest ipywidgets version
-      #   id: latest_version_ipywidgets
-      #   uses: jacobtomlinson/gha-anaconda-package-version@0.1.1
-      #   with:
-      #     org: "conda-forge"
-      #     package: "ipywidgets"
+       - name: Get latest ipywidgets version
+         id: latest_version_ipywidgets
+         uses: jacobtomlinson/gha-anaconda-package-version@0.1.1
+         with:
+           org: "conda-forge"
+           package: "ipywidgets"
 
-      # - name: Find and Replace ipywidgets
-      #   id: ipywidgets
-      #   uses: jacobtomlinson/gha-find-replace@0.1.1
-      #   with:
-      #     include: "meta.yaml"
-      #     find: "ipywidgets =.*"
-      #     replace: "ipywidgets =${{ steps.latest_version_ipywidgets.outputs.version }}"
+       - name: Find and Replace ipywidgets
+         id: ipywidgets
+         uses: jacobtomlinson/gha-find-replace@0.1.1
+         with:
+           include: "meta.yaml"
+           find: "ipywidgets =.*"
+           replace: "ipywidgets =${{ steps.latest_version_ipywidgets.outputs.version }}"
 
       - name: Get latest jupyter-server-proxy version
         id: latest_version_server_proxy
@@ -88,35 +88,35 @@ jobs:
           find: "jupyter-server-proxy =.*"
           replace: "jupyter-server-proxy =${{ steps.latest_version_server_proxy.outputs.version }}"
 
-      - name: Get latest jupyterhub version
-        id: latest_version_jupyterhub
+      - name: Get latest jupyterhub-singleruser version
+        id: latest_version_jupyterhub_singleuser
         uses: jacobtomlinson/gha-anaconda-package-version@0.1.1
         with:
           org: "conda-forge"
           package: "jupyterhub-singleuser"
 
-      - name: Find and Replace jupyterhub
-        id: jupyterhub
+      - name: Find and Replace jupyterhub-singleuser
+        id: jupyterhub_singleuser
         uses: jacobtomlinson/gha-find-replace@0.1.1
         with:
           include: "meta.yaml"
           find: "jupyterhub-singleuser =.*"
-          replace: "jupyterhub-singleuser =${{ steps.latest_version_jupyterhub.outputs.version }}"
+          replace: "jupyterhub-singleuser =${{ steps.latest_version_jupyterhub_singleuser.outputs.version }}"
 
-#       - name: Get latest jupyterlab version
-#         id: latest_version_jupyterlab
-#         uses: jacobtomlinson/gha-anaconda-package-version@0.1.1
-#         with:
-#           org: "conda-forge"
-#           package: "jupyterlab"
+       - name: Get latest jupyterlab version
+         id: latest_version_jupyterlab
+         uses: jacobtomlinson/gha-anaconda-package-version@0.1.1
+         with:
+           org: "conda-forge"
+           package: "jupyterlab"
 
-#       - name: Find and Replace jupyterlab
-#         id: jupyterlab
-#         uses: jacobtomlinson/gha-find-replace@0.1.1
-#         with:
-#           include: "meta.yaml"
-#           find: "jupyterlab =.*"
-#           replace: "jupyterlab =${{ steps.latest_version_jupyterlab.outputs.version }}"
+       - name: Find and Replace jupyterlab
+         id: jupyterlab
+         uses: jacobtomlinson/gha-find-replace@0.1.1
+         with:
+           include: "meta.yaml"
+           find: "jupyterlab =.*"
+           replace: "jupyterlab =${{ steps.latest_version_jupyterlab.outputs.version }}"
 
       - name: Get latest nbgitpuller version
         id: latest_version_nbgitpuller
@@ -134,7 +134,7 @@ jobs:
           replace: "nbgitpuller =${{ steps.latest_version_nbgitpuller.outputs.version }}"
 
       - name: Find and Replace CalVer
-        if: steps.dask.outputs.modifiedFiles > 0 || steps.labextension.outputs.modifiedFiles > 0 || steps.server_proxy.outputs.modifiedFiles > 0 || steps.jupyterhub.outputs.modifiedFiles > 0 || steps.jupyterlab.outputs.modifiedFiles > 0 || steps.nbgitpuller.outputs.modifiedFiles > 0
+        if: steps.dask.outputs.modifiedFiles > 0 || steps.labextension.outputs.modifiedFiles > 0 || steps.server_proxy.outputs.modifiedFiles > 0 || steps.jupyterhub_singleuser.outputs.modifiedFiles > 0 || steps.jupyterlab.outputs.modifiedFiles > 0 || steps.nbgitpuller.outputs.modifiedFiles > 0
         uses: jacobtomlinson/gha-find-replace@0.1.1
         with:
           include: "meta.yaml"
@@ -157,9 +157,9 @@ jobs:
                 -  pangeo-dask =`${{ steps.latest_version_dask.outputs.version }}`
                 -  dask-labextension =`${{ steps.latest_version_labext.outputs.version }}`
                 -  jupyter-server-proxy =`${{ steps.latest_version_server_proxy.outputs.version }}`
-                -  jupyterhub =`${{ steps.latest_version_jupyterhub.outputs.version }}`
-                -  ~jupyterlab =`${{ steps.latest_version_jupyterlab.outputs.version }}`~
-                -  ~ipywidgets =`${{ steps.latest_version_ipywidgets.outputs.version }}`~
+                -  jupyterhub-singleuser =`${{ steps.latest_version_jupyterhub_singleuser.outputs.version }}`
+                -  jupyterlab =`${{ steps.latest_version_jupyterlab.outputs.version }}`
+                -  ipywidgets =`${{ steps.latest_version_ipywidgets.outputs.version }}`
                 -  nbgitpuller =`${{ steps.latest_version_nbgitpuller.outputs.version }}`
 
             Notes before merging this PR:

--- a/.scripts/logging_utils.sh
+++ b/.scripts/logging_utils.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Provide a unified interface for the different logging
+# utilities CI providers offer. If unavailable, provide
+# a compatible fallback (e.g. bare `echo xxxxxx`).
+
+function startgroup {
+    # Start a foldable group of log lines
+    # Pass a single argument, quoted
+    case ${CI:-} in
+        azure )
+            echo "##[group]$1";;
+        travis )
+            echo "$1"
+            echo -en 'travis_fold:start:'"${1// /}"'\\r';;
+        * )
+            echo "$1";;
+    esac
+}
+
+function endgroup {
+    # End a foldable group of log lines
+    # Pass a single argument, quoted
+    case ${CI:-} in
+        azure )
+            echo "##[endgroup]";;
+        travis )
+            echo -en 'travis_fold:end:'"${1// /}"'\\r';;
+    esac
+}

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -5,6 +5,10 @@
 # changes to this script, consider a proposal to conda-smithy so that other feedstocks can also
 # benefit from the improvement.
 
+source .scripts/logging_utils.sh
+
+startgroup "Configure Docker"
+
 set -xeo pipefail
 
 THISDIR="$( cd "$( dirname "$0" )" >/dev/null && pwd )"
@@ -65,7 +69,9 @@ DOCKER_RUN_ARGS="${CONDA_FORGE_DOCKER_RUN_ARGS}"
 if [ -z "${CI}" ]; then
     DOCKER_RUN_ARGS="-it ${DOCKER_RUN_ARGS}"
 fi
+endgroup "Configure Docker"
 
+startgroup "Start Docker"
 export UPLOAD_PACKAGES="${UPLOAD_PACKAGES:-True}"
 docker run ${DOCKER_RUN_ARGS} \
            -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw,z,delegated \

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,5 @@
 BSD 3-clause license
-Copyright (c) 2015-2020, conda-forge contributors
+Copyright (c) 2015-2021, conda-forge contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/README.md
+++ b/README.md
@@ -106,9 +106,9 @@ build distinct package versions.
 
 In order to produce a uniquely identifiable distribution:
  * If the version of a package **is not** being increased, please add or increase
-   the [``build/number``](https://conda.io/docs/user-guide/tasks/build-packages/define-metadata.html#build-number-and-string).
+   the [``build/number``](https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#build-number-and-string).
  * If the version of a package **is** being increased, please remember to return
-   the [``build/number``](https://conda.io/docs/user-guide/tasks/build-packages/define-metadata.html#build-number-and-string)
+   the [``build/number``](https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#build-number-and-string)
    back to 0.
 
 Feedstock Maintainers

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2021.02.19" %}
+{% set version = "2021.03.01" %}
 
 package:
   name: pangeo-notebook
@@ -11,7 +11,7 @@ build:
 requirements:
   run:
     - pangeo-dask =2021.02.07
-    - dask-labextension =5
+    - dask-labextension =5.0.1
     - ipywidgets =7
     - jupyter-server-proxy =1.6.0
     - jupyterhub-singleuser =1.3.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,13 +11,12 @@ build:
 requirements:
   run:
     - pangeo-dask =2021.02.07
-    - dask-labextension =3
+    - dask-labextension =5
     - ipywidgets =7
     - jupyter-server-proxy =1.6.0
     - jupyterhub-singleuser =1.3.0
-    - jupyterlab =2
+    - jupyterlab =3
     - nbgitpuller =0.9.0
-    - nodejs >=12
 
 test:
   commands:


### PR DESCRIPTION
unpins things and drops nodejs since that's no longer strictly required for jupyterlab3 (#52)


Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.
